### PR TITLE
Feature/abrir y guardar soluciones

### DIFF
--- a/app/actividades/actividad.js
+++ b/app/actividades/actividad.js
@@ -109,6 +109,22 @@ var Actividad = Ember.Object.extend({
     return code;
   },
 
+  generarCodigoXMLComoString() {
+    Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
+    var codigo = this.generarCodigoXML();
+
+    function xml2string(node) {
+       if (typeof(XMLSerializer) !== 'undefined') {
+          var serializer = new XMLSerializer();
+          return serializer.serializeToString(node);
+       } else if (node.xml) {
+          return node.xml;
+       }
+    }
+
+    return xml2string(codigo);
+  },
+
   cargarCodigoDesdeStringXML(codigo) {
     var workspace = Blockly.getMainWorkspace();
     workspace.clear();

--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -182,21 +182,7 @@ export default Ember.Component.extend({
     },
 
     ver_codigo() {
-      Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
-      var code = this.get('actividad').generarCodigoXML();
-      var codigo_como_string = null;
-
-
-      function xml2string(node) {
-         if (typeof(XMLSerializer) !== 'undefined') {
-            var serializer = new XMLSerializer();
-            return serializer.serializeToString(node);
-         } else if (node.xml) {
-            return node.xml;
-         }
-      }
-
-      codigo_como_string = xml2string(code);
+      let codigo_como_string = this.get('actividad').generarCodigoXMLComoString();
       console.log(codigo_como_string);
       alert(codigo_como_string);
     },

--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+let VERSION_DEL_FORMATO_DE_ARCHIVO = 1;
+
 export default Ember.Component.extend({
   ejecutando: false,
   cola_deshacer: [],
@@ -244,9 +246,71 @@ export default Ember.Component.extend({
         catch((err) => {
           alert(err);
           this.set('envioEnCurso', false);
-        })
+        });
+    },
 
-      ;
+    cargarSolucion(archivo, contenido) {
+      let regex_file = /\.act$/;
+      let regex_version = /^\d+$/;
+      let data = null;
+      let solucion = null;
+
+      if (!regex_file.test(archivo.name)) {
+        alert("Lo siento, solo se permiten cargar archivos .act");
+        return;
+      }
+
+      if (archivo.size > 4000) {
+        alert("Lo siento, el archivo es demasiado grande para cargarse.");
+        return;
+      }
+
+      try {
+        data = JSON.parse(contenido);
+        solucion = atob(data.solucion);
+      } catch (e) {
+        console.error(e);
+        alert("Lo siento, el archivo está dañando.");
+        return;
+      }
+
+      if (!regex_version.test(data.version)) {
+        alert("Lo siento, la especificación de versión es incorrecta.");
+        return;
+      }
+
+      if (parseInt(data.version) > VERSION_DEL_FORMATO_DE_ARCHIVO) {
+        alert("Lo siento, el archivo no está soportado por esta versión.");
+        return;
+      }
+
+      if (this.get("actividad").id !== data.actividad) {
+        alert(`Lo siento, el archivo indica que es para otra actividad (${data.actividad}).`);
+        return;
+      }
+
+      this.get('actividad').cargarCodigoDesdeStringXML(solucion);
+    },
+
+    guardarSolucion() {
+      let nombre_de_la_actividad = this.get("actividad").id;
+      let nombre_surgerido = `${nombre_de_la_actividad}.act`;
+      let contenido = {
+        version: VERSION_DEL_FORMATO_DE_ARCHIVO,
+        actividad: nombre_de_la_actividad,
+        solucion: btoa(this.get('actividad').generarCodigoXMLComoString())
+      };
+      let contenido_como_string = JSON.stringify(contenido);
+
+      function descargar(text, name, type) {
+        var a = document.getElementById("placeholder");
+        var file = new Blob([text], {type: type});
+        a.href = URL.createObjectURL(file);
+        a.download = name;
+        a.click();
+      }
+
+      descargar(contenido_como_string, nombre_surgerido, 'application/octet-stream');
     }
 
   },

--- a/app/components/pilas-boton-cargar.js
+++ b/app/components/pilas-boton-cargar.js
@@ -1,0 +1,38 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'span',
+  cuandoSelecciona: null,
+
+  didInsertElement() {
+    this.$('#cargarActividadInput').change((event) => {
+      let archivo = event.target.files[0];
+
+      if (archivo) {
+        var reader = new FileReader();
+
+        reader.onload = (e) => {
+      	  let contenido = e.target.result;
+          
+          this.sendAction('cuandoSelecciona', archivo, contenido);
+        };
+
+        reader.readAsText(archivo);
+      }
+
+      // Fuerza a que se pueda cargar dos o más veces el mismo archivo.
+      this.limpiarInput();
+      return false;
+    });
+  },
+
+  limpiarInput() {
+    document.getElementById('cargarActividadInput').value = null;
+  },
+
+  actions: {
+    alPulsar() {
+      this.$("#cargarActividadInput").click();
+    }
+  }
+});

--- a/app/templates/components/pilas-blockly.hbs
+++ b/app/templates/components/pilas-blockly.hbs
@@ -13,7 +13,6 @@
   {{#if environment.debeMostrarBotonCodigoXML}}
     <button class='btn btn-warning' {{action "ver_codigo"}}>Ver código XML</button>
     <button class='btn btn-warning' {{action "ingresar_codigo"}}>Ingresar código XML</button>
-
   {{/if}}
 
   {{#if mostrarGuardar}}
@@ -35,7 +34,13 @@
 
   -->
 
-  <button class='btn btn-info border-right right' {{action "compartir"}}><i class='fa fa-twitter'></i> Compartir en twitter</button>
+
+
+  {{pilas-boton-cargar cuandoSelecciona="cargarSolucion"}}
+  <button class='btn btn-default' {{action "guardarSolucion"}}><i class="fa fa-download"></i> Guardar</button>
+
+
+  <button class='btn btn-info border-right right' {{action "compartir"}}><i class='fa fa-twitter'></i> Compartir</button>
 
 </div>
 

--- a/app/templates/components/pilas-boton-cargar.hbs
+++ b/app/templates/components/pilas-boton-cargar.hbs
@@ -1,0 +1,6 @@
+{{yield}}
+
+<input type='file' id="cargarActividadInput" class="hidden"/>
+<a id="placeholder" class="hidden">demo</a>
+
+<button class='btn btn-default' {{action "alPulsar"}}><i class="fa fa-folder-open-o"></i> Abrir</button>


### PR DESCRIPTION
Implementé una solución para abrir y guardar soluciones, funciona en navegadores y nwjs:

![pilas bloques 2016-06-23 21-37-19](https://cloud.githubusercontent.com/assets/99183/16324775/ef7dfbba-398d-11e6-9a9a-e3e3cfc9a212.png)

Lo único que me quedó fuera de la implementación (que se podría hacer más adelante), es permitirle al usuario importar código en una actividad que no corresponda u omitir el chequeo de versión (con la confirmación del usuario) como se menciona en la lista de features adicionales en el issue #109 

cc: @asanzo 