### PR TITLE
Encapsulando consulta de culpable en ElDetectiveChaparro

### DIFF
--- a/app/actividades/actividadElDetectiveChaparro.js
+++ b/app/actividades/actividadElDetectiveChaparro.js
@@ -29,7 +29,7 @@ var EsCulpable = AccionBuilder.buildSensor({
   id: 'Descubralculpable',
   descripcion: 'Estoy frente al culpable',
   icono: 'icono.culpable.png',
-  funcionSensor: 'colisiona_con(pilas.escena_actual().culpable) && pilas.escena_actual().culpable.teEncontraron()',
+  funcionSensor: 'colisionaConElCulpable() && pilas.escena_actual().culpable.teEncontraron()',
 });
 
 export default {


### PR DESCRIPTION
Añadí una validación para prevenir que una solución incorrecta produzca el error extraño que se menciona en el issue #149.

Este es un ejemplo de lo que produce la solución incorrecta:

![pilas bloques 2016-07-20 02-08-51](https://cloud.githubusercontent.com/assets/99183/16975706/61830714-4e1f-11e6-8681-fa4b12bc4f6e.png)


Por cierto, parte de esta implementación también impactó en el repositorio ejerciciosPilas, en particular este commit: 

https://github.com/Program-AR/ejerciciosPilas/commit/faad7eab64a8c5b52283b5bd2df923c69cbe94f6

