### PR TITLE
Quitando el limite de tamaño en los archivos de solución

### DIFF
--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -266,11 +266,6 @@ export default Ember.Component.extend({
         return;
       }
 
-      if (archivo.size > 400000) {
-        alert("Lo siento, el archivo es demasiado grande para cargarse.");
-        return;
-      }
-
       try {
         data = JSON.parse(contenido);
         solucion = atob(data.solucion);


### PR DESCRIPTION
El programa realizaba una validación de tamaño al cargar una solución, para prevenir que la aplicación intente abrir archivos demasiado grandes.

Pero como esto trajo problemas con algunas soluciones (ver #156) me pareció adecuado quitar la validación, en lugar de aumentar el tamaño de archivo soportado a ojo.

A futuro me gustaría recuperar esta validación, pero deberíamos tener una idea muy clara de cual sería el tamaño máximo de solución permitido para nosotros (en bytes).
